### PR TITLE
Usa la imagen de Ultralytics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
-FROM python:3
+FROM ultralytics/ultralytics
 
-WORKDIR /workdir
 COPY . .
 
 RUN apt update && apt install --yes make
-
-RUN pip install \
-    ultralytics
-
-#RUN make init

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 classification:
-	mv /workdir/camera_trap_photos/ /Trial_photos/
-	#cp -r /workdir/camera_trap_photos /Trial_photos
+	mv /workdir/camera_trap_photos/* /Trial_photos/
 	python main.py
 	cp -r /runs/detect/predict/ /workdir/cat_detected/
-	# Create a copy before purging /runs/detect
 	cp -r /runs/detect/predict/ /Backup_prediction/
 
 .PHONY: classification


### PR DESCRIPTION
Modificaciones del [_pull request_](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests):
- 🚚 Borra `WORKDIR` para mantener **Makefile**.
- 🐋 Utiliza la imagen de `ultralytics` para que las dependencias ya estén instaladas.
- 🔨 Copia las fotos en lugar de la carpeta `camera_trap_photos`

---

Hola @CarlosTMX. 🖖🏿

Trabajando con tu código notamos que había un problema al utiliza el `WORKDIR` en el **Dockerfile**.

### 🚚 Borra `WORKDIR` para mantener **Makefile**.
 El problema que teníamos es que sobreescribía la carpeta `/workdir` y así "perdíamos" el **Makefile**. [Aquí](https://docs.docker.com/reference/dockerfile/#workdir) esta la documentación del `WORKDIR`. Así que borramos la línea 3 del **Dockerfile**.


### 🐋 Utiliza la imagen de `ultralytics` para que las dependencias ya estén instaladas.
Cuando corregimos lo anterior en el **Dockerfile** tuvimos un nuevo error. La dependencia `opencv-python` utilizada por el paquete `ultralytics` no se instala bien.

![cv2_error](https://github.com/CarlosTMX/cetys_cat_recognition/assets/35377740/752ac36a-4b7e-451b-b8cd-df8d44234b0b)

 [Aquí](https://github.com/ultralytics/ultralytics/issues/4507) sugieren que utilicemos la imagen oficial de `ultralytics`. Cuando hicimos eso ya se instaló bien  `opencv-python`.

### 🔨 Copia las fotos en lugar de la carpeta `camera_trap_photos`
Por último, notamos que la instrucción `classification` en el **Makefile** copiaba la carpeta `camera_trap_photos` (y sus fotos). Modificamos esa línea para que solo copiara las fotos.


