### PR TITLE
🐋🪶 Use a lighter ultralytics image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ultralytics/ultralytics
+FROM ultralytics/ultralytics:latest-python
 
 COPY . .
 


### PR DESCRIPTION
Hola @CarlosTMX . 

Gracias por aceptar el _PR_ anterior. 

Al revisar el _actions_ vemos que el error es un problema en el espacio que GitHub nos asigna.
Creemos que si usamos una imagen más ligera, vamos a evitar este problema. 
No lo sabremos hasta que aceptes estos cambios que te proponemos y veamos correr el _actions_.

---

Revisando un poco más allá. Nos dimos cuenta que vamos a tener problemas con las carpetas de las que copias (ej. `/runs/predict/`) y hacia dónde las copiamos (ej. `/Trial_photos`). 
https://github.com/CarlosTMX/cetys_cat_recognition/blob/9e7a344c6700a5a876d48dd784560becca478f6d/Makefile#L3-L5

![Captura desde 2024-05-14 11-27-57](https://github.com/CarlosTMX/cetys_cat_recognition/assets/42744723/6639ad4a-79fc-43cc-a226-31b787dcdca4)

Pero eso lo revisamos una vez que logremos correr objetivo `classification`.
Quedamos atentos. 🤓