### PR TITLE
➕🐍 Install dill dependency to avoid warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM ultralytics/ultralytics:latest-python
 COPY . .
 
 RUN apt update && apt install --yes make
+
+RUN pip install dill


### PR DESCRIPTION
Hola @CarlosTMX 👋🏿

Creamos este _pr_ para atender la siguiente inquietud:

> En la etapa de Classify photos hay un warning que puede ser significativo

Esperamos que con este cambio ya no veamos el [warning](https://github.com/IslasGECI/ctf_cat_recognition/actions/runs/9104386757/job/25060213071#step:10:10). Si hay mejoras las podremos ver en la evaluación. 🤞🏾